### PR TITLE
fix issues/5 as suggested

### DIFF
--- a/certbot_plugin_websupport/dns.py
+++ b/certbot_plugin_websupport/dns.py
@@ -7,7 +7,7 @@ import hmac
 import hashlib
 import base64
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from certbot import errors
 from certbot import interfaces
@@ -205,7 +205,7 @@ class _WebsupportClient(object):
             "Authorization": "Basic {0}".format(base64.b64encode("{0}:{1}".format(self.api_key, signature).encode('utf-8')).decode('utf-8')),
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "Date": datetime.fromtimestamp(timestamp).isoformat()
+            "Date": datetime.fromtimestamp(timestamp, timezone.utc).isoformat()
         }
 
         return requests.request(method, '%s%s' % (API_ENDPOINT, path), headers=headers, json=data)


### PR DESCRIPTION
to fix the `zone_id` error, added a timezone.utc as suggested in https://github.com/Mordred/certbot-plugin-websupport/issues/5#issue-2279564696 .

It did not work/help for me though.

I did the renewal by running the command used in creating the certs..: `sudo certbot certonly -a dns --dns-credentials=/mypath/websupport.ini -d \*.mydomain.cz`